### PR TITLE
Refactor UDP switch utilities into separate modules

### DIFF
--- a/src/dlist.c
+++ b/src/dlist.c
@@ -1,0 +1,35 @@
+#include <stddef.h>
+#include "dlist.h"
+
+void dlist_add(dlist *dl, dlist_entry *e)
+{
+    if (dl->head == NULL) {
+        e->prev = NULL;
+        e->next = NULL;
+        dl->head = e;
+        dl->tail = e;
+    } else {
+        e->prev = dl->tail;
+        e->next = NULL;
+        dl->tail->next = e;
+        dl->tail = e;
+    }
+}
+
+void dlist_del(dlist *dl, dlist_entry *e)
+{
+    if (dl->head == e) {
+        dl->head = e->next;
+    }
+    if (dl->tail == e) {
+        dl->tail = e->prev;
+    }
+    if (e->prev) {
+        e->prev->next = e->next;
+    }
+    if (e->next) {
+        e->next->prev = e->prev;
+    }
+    e->prev = NULL;
+    e->next = NULL;
+}

--- a/src/dlist.h
+++ b/src/dlist.h
@@ -1,0 +1,17 @@
+#ifndef DLIST_H
+#define DLIST_H
+
+typedef struct dlist_entry {
+    struct dlist_entry *prev;
+    struct dlist_entry *next;
+} dlist_entry;
+
+typedef struct dlist {
+    dlist_entry *head;
+    dlist_entry *tail;
+} dlist;
+
+void dlist_add(dlist *dl, dlist_entry *e);
+void dlist_del(dlist *dl, dlist_entry *e);
+
+#endif /* DLIST_H */

--- a/src/vlan_bitmap.c
+++ b/src/vlan_bitmap.c
@@ -1,0 +1,19 @@
+#include "vlan_bitmap.h"
+
+void vlan_bitmap_set(vlan_bitmap *bm, uint16_t vlan_id)
+{
+    bm->bits[vlan_id / VLAN_BITMAP_BITS_PER_WORD] |=
+        1ULL << (vlan_id % VLAN_BITMAP_BITS_PER_WORD);
+}
+
+void vlan_bitmap_clear(vlan_bitmap *bm, uint16_t vlan_id)
+{
+    bm->bits[vlan_id / VLAN_BITMAP_BITS_PER_WORD] &=
+        ~(1ULL << (vlan_id % VLAN_BITMAP_BITS_PER_WORD));
+}
+
+int vlan_bitmap_test(const vlan_bitmap *bm, uint16_t vlan_id)
+{
+    return (bm->bits[vlan_id / VLAN_BITMAP_BITS_PER_WORD] >>
+            (vlan_id % VLAN_BITMAP_BITS_PER_WORD)) & 1;
+}

--- a/src/vlan_bitmap.h
+++ b/src/vlan_bitmap.h
@@ -1,0 +1,18 @@
+#ifndef VLAN_BITMAP_H
+#define VLAN_BITMAP_H
+
+#include <stdint.h>
+
+#define VLAN_VID_MASK   0xfff
+#define VLAN_BITMAP_BITS_PER_WORD (64)
+#define VLAN_BITMAP_WORDS ((VLAN_VID_MASK + VLAN_BITMAP_BITS_PER_WORD-1)/VLAN_BITMAP_BITS_PER_WORD)
+
+typedef struct vlan_bitmap {
+    uint64_t bits[VLAN_BITMAP_WORDS];
+} vlan_bitmap;
+
+void vlan_bitmap_set(vlan_bitmap *bm, uint16_t vlan_id);
+void vlan_bitmap_clear(vlan_bitmap *bm, uint16_t vlan_id);
+int vlan_bitmap_test(const vlan_bitmap *bm, uint16_t vlan_id);
+
+#endif /* VLAN_BITMAP_H */


### PR DESCRIPTION
## Summary
- extract doubly-linked list helpers into `dlist.c`/`dlist.h`
- move VLAN bitmap operations to `vlan_bitmap.c`/`vlan_bitmap.h`
- include new utility headers from `udp_switch.c`

## Testing
- `make` *(fails: fatal error: event2/event.h: No such file or directory)*
- `apt-get install -y libevent-dev libjansson-dev` *(fails: Unable to locate package)*


------
https://chatgpt.com/codex/tasks/task_e_688e4f352d988327a69806406e437f42